### PR TITLE
Fix text/json unmarshalling

### DIFF
--- a/starlarkproto.go
+++ b/starlarkproto.go
@@ -170,7 +170,7 @@ func (p *Proto) UnmarshalJSON(thread *starlark.Thread, fnname string, args starl
 	if err := msg.checkMutable(fnname); err != nil {
 		return nil, err
 	}
-	if err := proto.Unmarshal([]byte(str), msg); err != nil {
+	if err := options.Unmarshal([]byte(str), msg); err != nil {
 		return nil, err
 	}
 	return starlark.None, nil
@@ -215,7 +215,7 @@ func (p *Proto) UnmarshalText(thread *starlark.Thread, fnname string, args starl
 	if err := msg.checkMutable(fnname); err != nil {
 		return nil, err
 	}
-	if err := proto.Unmarshal([]byte(str), msg); err != nil {
+	if err := options.Unmarshal([]byte(str), msg); err != nil {
 		return nil, err
 	}
 	return starlark.None, nil

--- a/testdata/proto.star
+++ b/testdata/proto.star
@@ -106,5 +106,17 @@ m2 = test.Message()
 proto.unmarshal(data, m2)
 assert.eq(m, m2)
 
+# Marshal/Unmarshal text
+text = proto.marshal_text(m)
+m3 = test.Message()
+proto.unmarshal_text(text, m3)
+assert.eq(m, m3)
+
+# Marshal/Unmarshal json
+json = proto.marshal_json(m)
+m4 = test.Message()
+proto.unmarshal_json(json, m4)
+assert.eq(m, m4)
+
 # print(proto.marshal_json(m))
 # print(proto.marshal_text(m))


### PR DESCRIPTION
Ran into this when trying to use your Starlark library. Both were marshalling correctly, but trying to unmarshal from wire format.

Before this change, both new test cases would have failed with `cannot parse invalid wire-format data`.